### PR TITLE
Allow robot collbody param as spheres

### DIFF
--- a/examples/03_kin_with_coll.py
+++ b/examples/03_kin_with_coll.py
@@ -21,7 +21,7 @@ import viser
 import viser.extras
 
 from jaxmp import JaxKinTree, RobotFactors
-from jaxmp.coll import Plane, RobotColl, Sphere, CollGeom
+from jaxmp.coll import Plane, RobotColl, Sphere, CollGeom, link_to_spheres
 from jaxmp.extras.urdf_loader import load_urdf
 
 
@@ -35,6 +35,7 @@ def main(
 
     urdf = load_urdf(robot_description, robot_urdf_path)
     robot_coll = RobotColl.from_urdf(urdf)
+    robot_coll_sph = RobotColl.from_urdf(urdf, link_to_spheres)
     kin = JaxKinTree.from_urdf(urdf)
     rest_pose = (kin.limits_upper + kin.limits_lower) / 2
     assert isinstance(robot_coll.coll, CollGeom)
@@ -63,13 +64,31 @@ def main(
     server.scene.add_mesh_trimesh("sphere_obs/mesh", sphere_obs.to_trimesh())
 
     # Visualize collision distances.
-    self_coll_value = server.gui.add_number(
-        "max. coll (self)", 0.0, step=0.01, disabled=True
-    )
-    world_coll_value = server.gui.add_number(
-        "max. coll (world)", 0.0, step=0.01, disabled=True
-    )
-    visualize_coll = server.gui.add_checkbox("Visualize spheres", False)
+    with server.gui.add_folder("Collision (cylinder)"):
+        self_coll_value = server.gui.add_number(
+            "max. coll (self)", 0.0, step=0.01, disabled=True
+        )
+        world_coll_value = server.gui.add_number(
+            "max. coll (world)", 0.0, step=0.01, disabled=True
+        )
+        visualize_coll = server.gui.add_checkbox("Visualize coll", False)
+        @visualize_coll.on_update
+        def _(_):
+            if visualize_coll_sph.value and visualize_coll.value:
+                visualize_coll_sph.value = False
+
+    with server.gui.add_folder("Collision (sphere)"):
+        self_coll_value_sph = server.gui.add_number(
+            "max. coll (self)", 0.0, step=0.01, disabled=True
+        )
+        world_coll_value_sph = server.gui.add_number(
+            "max. coll (world)", 0.0, step=0.01, disabled=True
+        )
+        visualize_coll_sph = server.gui.add_checkbox("Visualize coll", False)
+        @visualize_coll_sph.on_update
+        def _(_):
+            if visualize_coll.value and visualize_coll_sph.value:
+                visualize_coll.value = False
 
     # Add GUI elements, to let user interact with the robot joints.
     timing_handle = server.gui.add_number("Time (ms)", 0.01, disabled=True)
@@ -105,20 +124,27 @@ def main(
 
     has_jitted = False
     while True:
-        if visualize_coll.value:
-            assert isinstance(robot_coll.coll, CollGeom)
-            collbody_handle = server.scene.add_mesh_trimesh(
-                "coll",
-                robot_coll.coll.transform(
-                    jaxlie.SE3(
-                        kin.forward_kinematics(joints)[
-                            ..., robot_coll.link_joint_idx, :
-                        ]
-                    )
-                ).to_trimesh(),
-            )
-        elif collbody_handle is not None:
-            collbody_handle.remove()
+        for (_visualize_coll, _robot_coll) in [
+            (visualize_coll, robot_coll),
+            (visualize_coll_sph, robot_coll_sph),
+        ]:
+            if _visualize_coll.value:
+                assert isinstance(_robot_coll.coll, CollGeom)
+                collbody_handle = server.scene.add_mesh_trimesh(
+                    "coll",
+                    _robot_coll.coll.transform(
+                        jaxlie.SE3(
+                            kin.forward_kinematics(joints)[
+                                ..., _robot_coll.link_joint_idx, :
+                            ]
+                        )
+                    ).to_trimesh(),
+                )
+                break
+        else:
+            if collbody_handle is not None:
+                collbody_handle.remove()
+                collbody_handle = None
 
         if len(target_name_handles) == 0:
             time.sleep(0.1)
@@ -170,19 +196,17 @@ def main(
             target_frame_handle.position = onp.array(T_target_world)[4:]
             target_frame_handle.wxyz = onp.array(T_target_world)[:4]
 
-        urdf_vis.update_cfg(onp.array(joints))
-
-        coll = robot_coll.at_joints(kin, joints)
-        assert isinstance(coll, CollGeom)
-        dist = collide(coll, coll.reshape(-1, 1)).dist
-        coll_list = jnp.array(robot_coll.self_coll_list)
-        dist = dist[coll_list[:, 0], coll_list[:, 1]]
-        self_coll_value.value = dist.min().item()
-
-        world_coll_value.value = min(
-            collide(coll, ground_obs).dist.min().item(),
-            collide(coll, curr_sphere_obs).dist.min().item(),
-        )
+        # Update collision distances.
+        for (_robot_coll, _self_coll_value, _world_coll_value) in [
+            (robot_coll, self_coll_value, world_coll_value),
+            (robot_coll_sph, self_coll_value_sph, world_coll_value_sph),
+        ]:
+            _dist = _robot_coll.self_coll_dist(kin, joints)
+            _self_coll_value.value = _dist.item()
+            _world_coll_value.value = min(
+                _robot_coll.world_coll_dist(kin, joints, ground_obs).item(),
+                _robot_coll.world_coll_dist(kin, joints, curr_sphere_obs).item(),
+            )
 
 
 @jdc.jit

--- a/examples/03_kin_with_coll.py
+++ b/examples/03_kin_with_coll.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import time
 import jax
 import jaxls
-from jaxmp.coll import collide
 
 from loguru import logger
 import tyro
@@ -72,6 +71,7 @@ def main(
             "max. coll (world)", 0.0, step=0.01, disabled=True
         )
         visualize_coll = server.gui.add_checkbox("Visualize coll", False)
+
         @visualize_coll.on_update
         def _(_):
             if visualize_coll_sph.value and visualize_coll.value:
@@ -85,6 +85,7 @@ def main(
             "max. coll (world)", 0.0, step=0.01, disabled=True
         )
         visualize_coll_sph = server.gui.add_checkbox("Visualize coll", False)
+
         @visualize_coll_sph.on_update
         def _(_):
             if visualize_coll.value and visualize_coll_sph.value:
@@ -124,7 +125,7 @@ def main(
 
     has_jitted = False
     while True:
-        for (_visualize_coll, _robot_coll) in [
+        for _visualize_coll, _robot_coll in [
             (visualize_coll, robot_coll),
             (visualize_coll_sph, robot_coll_sph),
         ]:
@@ -146,6 +147,8 @@ def main(
                 collbody_handle.remove()
                 collbody_handle = None
 
+        time.sleep(0.1)
+        continue
         if len(target_name_handles) == 0:
             time.sleep(0.1)
             continue
@@ -197,7 +200,7 @@ def main(
             target_frame_handle.wxyz = onp.array(T_target_world)[:4]
 
         # Update collision distances.
-        for (_robot_coll, _self_coll_value, _world_coll_value) in [
+        for _robot_coll, _self_coll_value, _world_coll_value in [
             (robot_coll, self_coll_value, world_coll_value),
             (robot_coll_sph, self_coll_value_sph, world_coll_value_sph),
         ]:

--- a/src/jaxmp/coll/__init__.py
+++ b/src/jaxmp/coll/__init__.py
@@ -9,3 +9,5 @@ from ._collide_types import Ellipsoid as Ellipsoid
 from ._collide_types import Convex as Convex
 from ._collide_types import Cylinder as Cylinder
 from ._robot_coll import RobotColl as RobotColl
+from ._robot_coll import link_to_capsules as link_to_capsules
+from ._robot_coll import link_to_spheres as link_to_spheres

--- a/src/jaxmp/coll/_collide.py
+++ b/src/jaxmp/coll/_collide.py
@@ -173,9 +173,8 @@ def collide(
 
 def _get_coll_func(geom_0, geom_1) -> tuple[Callable, CollGeom, CollGeom]:
     for key, func in _COLLISION_FUNC.items():
-        if (
-            (key[0] not in MJX_TO_COLL or key[1] not in MJX_TO_COLL) or
-            (key[1] not in MJX_TO_COLL or key[0] not in MJX_TO_COLL)
+        if (key[0] not in MJX_TO_COLL or key[1] not in MJX_TO_COLL) or (
+            key[1] not in MJX_TO_COLL or key[0] not in MJX_TO_COLL
         ):
             continue
         if isinstance(geom_0, MJX_TO_COLL[key[0]]) and isinstance(

--- a/src/jaxmp/coll/_collide.py
+++ b/src/jaxmp/coll/_collide.py
@@ -173,7 +173,10 @@ def collide(
 
 def _get_coll_func(geom_0, geom_1) -> tuple[Callable, CollGeom, CollGeom]:
     for key, func in _COLLISION_FUNC.items():
-        if key[0] not in MJX_TO_COLL or key[1] not in MJX_TO_COLL:
+        if (
+            (key[0] not in MJX_TO_COLL or key[1] not in MJX_TO_COLL) or
+            (key[1] not in MJX_TO_COLL or key[0] not in MJX_TO_COLL)
+        ):
             continue
         if isinstance(geom_0, MJX_TO_COLL[key[0]]) and isinstance(
             geom_1, MJX_TO_COLL[key[1]]

--- a/src/jaxmp/coll/_collide_types.py
+++ b/src/jaxmp/coll/_collide_types.py
@@ -152,6 +152,12 @@ class Sphere(CollGeom):
         sphere.vertices = trimesh.transform_points(sphere.vertices, tf)
         return sphere
 
+    def merge_to_cylinder(self) -> Cylinder:
+        """
+        Given sphere of shape (*batch) == (2, *_batch), merge to a cylinder of shape (*_batch).
+        """
+        raise NotImplementedError
+
 
 @jdc.pytree_dataclass
 class Capsule(CollGeom):
@@ -212,8 +218,10 @@ class Capsule(CollGeom):
         spheres = Sphere.from_center_and_radius(
             jnp.broadcast_to(jnp.zeros(3), (*radii.shape[:-1], 3)), radii
         )
-        offset = (heights - radii) * jnp.array([[0, 0, 1]])
-        offset = offset * jnp.broadcast_to(jnp.linspace(-1, 1, n_segments)[:, None], (n_segments, *offset.shape[1:]))
+        offset = heights * jnp.array([[0, 0, 1]])
+        offset = offset * jnp.broadcast_to(
+            jnp.linspace(-1, 1, n_segments)[:, None], (n_segments, *offset.shape[1:])
+        )
         tf = self.pose @ jaxlie.SE3.from_translation(offset)
 
         spheres = spheres.transform(tf)

--- a/src/jaxmp/coll/_robot_coll.py
+++ b/src/jaxmp/coll/_robot_coll.py
@@ -307,20 +307,20 @@ class RobotColl:
         """Convert the self-collision list (specified in links) to a matrix (in collbodies)."""
         # Create a matrix of size (num_colls, num_colls)
         matrix = jnp.zeros((num_colls, num_colls))
-        
+
         # For each pair of links in self_coll_list
         for link_0, link_1 in self_coll_list:
             # Get the collision bodies for each link
             colls_0 = link_to_colls[link_0]
             colls_1 = link_to_colls[link_1]
-            
+
             # For each pair of collision bodies
             for c0 in colls_0:
                 for c1 in colls_1:
                     # Mark both directions in the matrix
                     matrix = matrix.at[c0, c1].set(1.0)
                     matrix = matrix.at[c1, c0].set(1.0)
-            
+
         return matrix
 
     def at_joints(


### PR DESCRIPTION
This would be useful for collision checking along a path.

- [x] Decompose robot capsules to spheres
- [x] Validate collision dist is consistent between capsule and sphere reps
- [x] Implement logic for (sphere_0, sphere_1) -> (capsule)