### PR TITLE
[patch] Speed up JIT time by removing unnecessary for / list comprehension

### DIFF
--- a/examples/03_kin_with_coll.py
+++ b/examples/03_kin_with_coll.py
@@ -147,8 +147,6 @@ def main(
                 collbody_handle.remove()
                 collbody_handle = None
 
-        time.sleep(0.1)
-        continue
         if len(target_name_handles) == 0:
             time.sleep(0.1)
             continue
@@ -223,7 +221,7 @@ def solve_ik_with_coll(
     *,
     pos_weight: float = 5.0,
     rot_weight: float = 1.0,
-    rest_weight: float = 0.01,
+    rest_weight: float = 0.001,
     limit_weight: float = 100.0,
     self_coll_weight: float = 5.0,
     world_coll_weight: float = 10.0,
@@ -268,19 +266,18 @@ def solve_ik_with_coll(
     )
 
     # Add collision factors.
-    self_coll_factors = RobotFactors.self_coll_factors(
+    self_coll_factor = RobotFactors.self_coll_factor(
         JointVar, joint_var_idx, kin, robot_coll, 0.05, self_coll_weight
     )
     world_coll_factors = [
-        RobotFactors.get_world_coll_factors(
+        RobotFactors.world_coll_factor(
             JointVar, joint_var_idx, kin, robot_coll, coll, 0.1, world_coll_weight
         )
         for coll in world_coll
     ]
 
-    factors.extend(self_coll_factors)
-    for world_coll_factor in world_coll_factors:
-        factors.extend(world_coll_factor)
+    factors.append(self_coll_factor)
+    factors.extend(world_coll_factors)
 
     # Solve IK.
     joint_vars = [JointVar(joint_var_idx)]

--- a/examples/03_kin_with_coll.py
+++ b/examples/03_kin_with_coll.py
@@ -185,7 +185,7 @@ def main(
         # Update timing info.
         timing_handle.value = (time.time() - start) * 1000
         if not has_jitted:
-            logger.info("JIT compile + runing took {} ms.", timing_handle.value)
+            logger.info("JIT compile + running took {} ms.", timing_handle.value)
             has_jitted = True
 
         urdf_vis.update_cfg(onp.array(joints))

--- a/scripts/profile_ik.py
+++ b/scripts/profile_ik.py
@@ -225,8 +225,8 @@ def solve_ik(
         joint_var_values.append(ConstrainedSE3Var(pose_var_idx))
 
     if include_self_coll:
-        factors.extend(
-            RobotFactors.self_coll_factors(
+        factors.append(
+            RobotFactors.self_coll_factor(
                 JointVar, joint_var_idx, kin, coll, 0.05, self_coll_weight
             )
         )

--- a/src/jaxmp/coll/_collide.py
+++ b/src/jaxmp/coll/_collide.py
@@ -64,7 +64,7 @@ class Collision:
 
 def colldist_from_sdf(
     _dist: jax.Array,
-    activation_dist: float = 0.05,
+    activation_dist: jax.Array | float = 0.05,
 ) -> jax.Array:
     """
     Convert a signed distance field to a collision distance field,


### PR DESCRIPTION
Tries to address #12 partially.

At cf9dfee617bd337545a9e9d70a7709b9269ca5d4 (i.e., before #1 ), it would take around ~9s to JIT compile for collision-aware IK with yumi and panda; at b192178d62e86d12ce1c0d1d4a22cc853156c056 (~main as of 12/8) it takes around 61s to JIT panda, and 18 seconds for yumi.

With this push, compilation time is brought down to ~20s for panda and ~16s for yumi.

In general, there's a lot of code inefficiencies to be addressed, esp with control workflows.