### PR TITLE
Improve JIT speed + runtime speed

### DIFF
--- a/examples/04_trajopt.py
+++ b/examples/04_trajopt.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 import jax
 from robot_descriptions.loaders.yourdfpy import load_robot_description
+from loguru import logger
 import viser
 import viser.extras
 
@@ -49,75 +50,66 @@ def solve_traj_gomp(
         retract_fn=retract_fn,
     ): ...
 
+    ik_weights = jnp.array([pos_weight] * 3 + [rot_weight] * 3)
     def ik_cost(
         vals: jaxls.VarValues,
-        kin: JaxKinTree,
         joint_var: jaxls.Var[jax.Array],
         target_pose: jaxlie.SE3,
         target_pose_offset_var: ConstrainedSE3Var,
-        target_joint_idx: jdc.Static[int],
-        weights: jax.Array,
     ) -> jax.Array:
         """Pose cost."""
         joint_cfg: jax.Array = vals[joint_var]
         target_pose_offset = vals[target_pose_offset_var]
         Ts_joint_world = kin.forward_kinematics(joint_cfg)
         residual = (
-            (jaxlie.SE3(Ts_joint_world[target_joint_idx])).inverse()
+            (jaxlie.SE3(Ts_joint_world[target_joint_indices])).inverse()
             @ (target_pose @ target_pose_offset)
         ).log()
-        weights = jnp.broadcast_to(weights, residual.shape)
-        assert residual.shape == weights.shape
-        return (residual * weights).flatten()
+        return (residual * ik_weights).flatten()
 
     _, timesteps, pose_dim = target_pose.wxyz_xyz.shape
+    target_pose = jaxlie.SE3(jnp.swapaxes(target_pose.wxyz_xyz, 0, 1))
     factors = []
 
-    for tstep in range(timesteps):
-        for idx, target_joint_idx in enumerate(target_joint_indices):
-            factors.extend(
-                [
-                    jaxls.Factor(
-                        ik_cost,
-                        (
-                            kin,
-                            JointVar(tstep),
-                            jaxlie.SE3(target_pose.wxyz_xyz[idx, tstep]),
-                            ConstrainedSE3Var(idx),
-                            target_joint_idx,
-                            jnp.array([pos_weight] * 3 + [rot_weight] * 3),
-                        ),
-                    ),
-                ]
-            )
-        factors.extend(
-            [
-                RobotFactors.limit_cost_factor(
-                    JointVar,
-                    tstep,
-                    kin,
-                    jnp.array([limit_weight] * kin.num_actuated_joints),
-                ),
-                RobotFactors.rest_cost_factor(
-                    JointVar,
-                    tstep,
-                    jnp.array([rest_weight] * kin.num_actuated_joints),
-                ),
-            ]
+    factors.append(
+        jaxls.Factor(
+            ik_cost,
+            (
+                JointVar(jnp.arange(timesteps)),
+                target_pose,
+                ConstrainedSE3Var(jnp.zeros((timesteps,))),
+            ),
+        ),
+    )
+
+    factors.extend(
+        [
+            RobotFactors.limit_cost_factor(
+                JointVar,
+                jnp.arange(timesteps),
+                kin,
+                jnp.array([limit_weight] * kin.num_actuated_joints),
+            ),
+            RobotFactors.rest_cost_factor(
+                JointVar,
+                jnp.arange(timesteps),
+                jnp.array([rest_weight] * kin.num_actuated_joints),
+            ),
+        ]
+    )
+
+    factors.append(
+        RobotFactors.smoothness_cost_factor(
+            JointVar,
+            jnp.arange(1, timesteps),
+            jnp.arange(0, timesteps-1),
+            jnp.array([smoothness_weight] * kin.num_actuated_joints),
         )
-        if tstep > 0:
-            factors.append(
-                RobotFactors.smoothness_cost_factor(
-                    JointVar,
-                    tstep,
-                    tstep - 1,
-                    jnp.array([smoothness_weight] * kin.num_actuated_joints),
-                )
-            )
+    )
 
     traj_vars = [
         JointVar(jnp.arange(timesteps)),
-        ConstrainedSE3Var(jnp.arange(len(rest_pose))),
+        ConstrainedSE3Var(0),
     ]
     graph = jaxls.FactorGraph.make(
         factors,
@@ -126,10 +118,11 @@ def solve_traj_gomp(
     )
     solution = graph.solve(
         initial_vals=jaxls.VarValues.make(traj_vars),
-        trust_region=jaxls.TrustRegionConfig(lambda_initial=0.2),
+        trust_region=jaxls.TrustRegionConfig(lambda_initial=1.0),
         termination=jaxls.TerminationConfig(
             gradient_tolerance=1e-5, parameter_tolerance=1e-5
         ),
+        verbose=False,
     )
     return jnp.stack([solution[JointVar(tstep)] for tstep in range(timesteps)])
 
@@ -150,6 +143,8 @@ def main(
     trajectory = onp.load(
         Path(__file__).parent / "assets/yumi_trajectory.npy", allow_pickle=True
     ).item()  # {'joint_name': [time, wxyz_xyz]}
+    for joint_name, joint_pose_traj in trajectory.items():
+        trajectory[joint_name] = joint_pose_traj[:10]
     timesteps = list(trajectory.values())[0].shape[0]
     rest_pose = (kin.limits_upper + kin.limits_lower) / 2
 
@@ -172,20 +167,6 @@ def main(
             axes_radius=0.004,
         )
 
-    freeze_target_xyz_xyz = jnp.ones(6)
-    traj = solve_traj_gomp(
-        kin,
-        target_pose,
-        target_joint_indices,
-        pos_weight=pos_weight,
-        rot_weight=rot_weight,
-        rest_weight=rest_weight,
-        limit_weight=limit_weight,
-        smoothness_weight=smoothness_weight,
-        rest_pose=rest_pose,
-        freeze_target_xyz_xyz=freeze_target_xyz_xyz,
-    )
-
     with server.gui.add_folder("Target frame"):
         freeze_target_x = server.gui.add_checkbox("Freeze x", initial_value=True)
         freeze_target_y = server.gui.add_checkbox("Freeze y", initial_value=True)
@@ -196,8 +177,7 @@ def main(
 
     update_traj_handle = server.gui.add_button("Regenerate traj")
 
-    @update_traj_handle.on_click
-    def _(_):
+    def generate_traj():
         nonlocal traj
         update_traj_handle.disabled = True
 
@@ -222,6 +202,7 @@ def main(
                 target_pose.wxyz_xyz[..., 4:] - traj_center
             )
         )
+        start = time.time()
         traj = solve_traj_gomp(
             kin,
             target_pose,
@@ -234,7 +215,14 @@ def main(
             rest_pose=rest_pose,
             freeze_target_xyz_xyz=freeze_target_xyz_xyz,
         )
+        end = time.time()
+        logger.info(f"Trajectory optimization took {end - start:.2f}s")
         update_traj_handle.disabled = False
+    
+    update_traj_handle.on_click(lambda _: generate_traj())
+
+    traj = None
+    generate_traj()
 
     # Visualize!
     slider = server.gui.add_slider(
@@ -243,6 +231,7 @@ def main(
 
     @slider.on_update
     def _(_) -> None:
+        assert traj is not None
         urdf_orig.update_cfg(onp.array(traj[slider.value]))
 
         Ts_world_joint = onp.array(kin.forward_kinematics(traj[slider.value]))

--- a/examples/04_trajopt.py
+++ b/examples/04_trajopt.py
@@ -144,8 +144,6 @@ def main(
     trajectory = onp.load(
         Path(__file__).parent / "assets/yumi_trajectory.npy", allow_pickle=True
     ).item()  # {'joint_name': [time, wxyz_xyz]}
-    for joint_name, joint_pose_traj in trajectory.items():
-        trajectory[joint_name] = joint_pose_traj[:10]
     timesteps = list(trajectory.values())[0].shape[0]
     rest_pose = (kin.limits_upper + kin.limits_lower) / 2
 

--- a/examples/04_trajopt.py
+++ b/examples/04_trajopt.py
@@ -51,6 +51,7 @@ def solve_traj_gomp(
     ): ...
 
     ik_weights = jnp.array([pos_weight] * 3 + [rot_weight] * 3)
+
     def ik_cost(
         vals: jaxls.VarValues,
         joint_var: jaxls.Var[jax.Array],
@@ -102,7 +103,7 @@ def solve_traj_gomp(
         RobotFactors.smoothness_cost_factor(
             JointVar,
             jnp.arange(1, timesteps),
-            jnp.arange(0, timesteps-1),
+            jnp.arange(0, timesteps - 1),
             jnp.array([smoothness_weight] * kin.num_actuated_joints),
         )
     )
@@ -218,7 +219,7 @@ def main(
         end = time.time()
         logger.info(f"Trajectory optimization took {end - start:.2f}s")
         update_traj_handle.disabled = False
-    
+
     update_traj_handle.on_click(lambda _: generate_traj())
 
     traj = None

--- a/src/jaxmp/extras/solve_ik.py
+++ b/src/jaxmp/extras/solve_ik.py
@@ -97,8 +97,8 @@ def solve_ik(
     )
 
     if use_manipulability:
-        factors.extend(
-            RobotFactors.manipulability_cost_factors(
+        factors.append(
+            RobotFactors.manipulability_cost_factor(
                 JointVar,
                 joint_var_idx,
                 kin,

--- a/src/jaxmp/kinematics.py
+++ b/src/jaxmp/kinematics.py
@@ -56,8 +56,13 @@ class JaxKinTree:
     joint_vel_limit: Float[Array, " act_joints"]
     """Joint limit velocities for each actuated joint."""
 
+    unroll_fk: jdc.Static[bool]
+    """Whether to unroll the forward kinematics `fori_loop`.
+    Unrolling seems useful for collision-aware IK on GPU.
+    """
+
     @staticmethod
-    def from_urdf(urdf: yourdfpy.URDF) -> JaxKinTree:
+    def from_urdf(urdf: yourdfpy.URDF, unroll_fk: bool = False) -> JaxKinTree:
         """Build a differentiable robot model from a URDF."""
 
         # Get the parent indices + joint twist parameters.
@@ -137,6 +142,7 @@ class JaxKinTree:
             limits_upper=limits_upper,
             joint_names=joint_names,
             joint_vel_limit=joint_vel_limits,
+            unroll_fk=unroll_fk,
         )
 
     @staticmethod
@@ -278,6 +284,7 @@ class JaxKinTree:
             upper=self.num_joints,
             body_fun=compute_joint,
             init_val=Ts_world_parent,
+            unroll=self.unroll_fk,
         )
 
         assert Ts_world_joint.shape == (*batch_axes, self.num_joints, 7)

--- a/src/jaxmp/robot_factors.py
+++ b/src/jaxmp/robot_factors.py
@@ -218,6 +218,7 @@ class RobotFactors:
         `activation_dist` and `weights` should be given in terms of the collision link pairs,
         e.g., through `RobotColl.coll_weight`.
         """
+
         def self_coll_cost(
             vals: jaxls.VarValues,
             var: jaxls.Var[Array],

--- a/src/jaxmp/robot_factors.py
+++ b/src/jaxmp/robot_factors.py
@@ -74,11 +74,7 @@ class RobotFactors:
 
         def ik_cost(
             vals: jaxls.VarValues,
-            kin: JaxKinTree,
-            target_pose: jaxlie.SE3,
-            target_joint_idx: jax.Array,
             var: jaxls.Var[Array],
-            weights: Array,
             base_tf_var: jaxls.Var[jaxlie.SE3] | jaxlie.SE3 | None = None,
             ee_tf_var: jaxls.Var[jaxlie.SE3] | jaxlie.SE3 | None = None,
         ):
@@ -106,8 +102,6 @@ class RobotFactors:
                 ).inverse()
                 @ (target_pose)
             ).log()
-            weights = jnp.broadcast_to(weights, residual.shape)
-            assert residual.shape == weights.shape
             return (residual * weights).flatten()
 
         # Handle optional base and offset transforms.
@@ -129,11 +123,7 @@ class RobotFactors:
         return jaxls.Factor(
             ik_cost,
             (
-                kin,
-                target_pose,
-                target_joint_idx,
                 JointVarType(var_idx),
-                weights,
                 base_se3_var,
                 ee_se3_var,
             ),
@@ -150,9 +140,7 @@ class RobotFactors:
 
         def limit_cost(
             vals: jaxls.VarValues,
-            kin: JaxKinTree,
             var: jaxls.Var[Array],
-            weights: Array,
         ) -> Array:
             joint_cfg: jax.Array = vals[var]
             residual_upper = jnp.maximum(0.0, joint_cfg - kin.limits_upper)
@@ -161,7 +149,7 @@ class RobotFactors:
             assert residual.shape == weights.shape
             return residual * weights
 
-        return jaxls.Factor(limit_cost, (kin, JointVarType(var_idx), weights))
+        return jaxls.Factor(limit_cost, (JointVarType(var_idx),))
 
     @staticmethod
     def limit_vel_cost_factor(
@@ -177,11 +165,8 @@ class RobotFactors:
 
         def vel_limit_cost(
             vals: jaxls.VarValues,
-            kin: JaxKinTree,
             var_curr: jaxls.Var[Array],
             var_prev: jaxls.Var[Array] | Array,
-            dt: float,
-            weights: Array,
         ) -> Array:
             prev = vals[var_prev] if isinstance(var_prev, jaxls.Var) else var_prev
             joint_vel = (vals[var_curr] - prev) / dt
@@ -198,7 +183,7 @@ class RobotFactors:
 
         return jaxls.Factor(
             vel_limit_cost,
-            (kin, JointVarType(var_idx), var_prev, dt, weights),
+            (JointVarType(var_idx), var_prev),
         )
 
     @staticmethod
@@ -212,14 +197,13 @@ class RobotFactors:
         def rest_cost(
             vals: jaxls.VarValues,
             var: jaxls.Var[Array],
-            weights: Array,
         ) -> Array:
             default = var.default_factory()
             assert default is not None
             assert default.shape == vals[var].shape and default.shape == weights.shape
             return (vals[var] - default) * weights
 
-        return jaxls.Factor(rest_cost, (JointVarType(var_idx), weights))
+        return jaxls.Factor(rest_cost, (JointVarType(var_idx),))
 
     @staticmethod
     def self_coll_factor(
@@ -234,8 +218,6 @@ class RobotFactors:
         `activation_dist` and `weights` should be given in terms of the collision link pairs,
         e.g., through `RobotColl.coll_weight`.
         """
-
-        # jaxls does not support static/varying treedefs, for batching.
         def self_coll_cost(
             vals: jaxls.VarValues,
             var: jaxls.Var[Array],
@@ -370,7 +352,6 @@ class RobotFactors:
             vals: jaxls.VarValues,
             var_curr: jaxls.Var[Array],
             var_past: jaxls.Var[Array],
-            weights: Array,
         ) -> Array:
             residual = vals[var_curr] - vals[var_past]
             assert residual.shape == weights.shape
@@ -381,25 +362,23 @@ class RobotFactors:
             (
                 JointVarType(var_idx_curr),
                 JointVarType(var_idx_past),
-                weights,
             ),
         )
 
     @staticmethod
-    def manipulability_cost_factors(
+    def manipulability_cost_factor(
         JointVarType: type[jaxls.Var[Array]],
         var_idx: jax.Array | int,
         kin: JaxKinTree,
         target_joint_indices: jax.Array,
         weights: float,
-    ) -> list[jaxls.Factor]:
+    ) -> jaxls.Factor:
         """Manipulability cost."""
 
         def manipulability_cost(
             vals: jaxls.VarValues,
-            kin: JaxKinTree,
             var: jaxls.Var[Array],
-            target_joint_idx: int,
+            target_joint_idx: jax.Array,
         ) -> Array:
             joint_cfg: jax.Array = vals[var]
             manipulability = RobotFactors.manip_yoshikawa(
@@ -407,19 +386,20 @@ class RobotFactors:
             )
             return ((1 / manipulability + 1e-6) * weights).flatten()
 
-        return [
-            jaxls.Factor(
-                manipulability_cost,
-                (kin, JointVarType(var_idx), target_joint_idx),
-            )
-            for target_joint_idx in target_joint_indices
-        ]
+        assert len(target_joint_indices.shape) == 1
+        return jaxls.Factor(
+            manipulability_cost,
+            (
+                JointVarType(jnp.full((target_joint_indices.shape[0],), var_idx)),
+                target_joint_indices,
+            ),
+        )
 
     @staticmethod
     def manip_yoshikawa(
         kin: JaxKinTree,
         cfg: Array,
-        target_joint_idx: int,
+        target_joint_idx: jax.Array,
     ) -> Array:
         """Manipulability, as the determinant of the Jacobian."""
         jacobian = jax.jacfwd(


### PR DESCRIPTION
Another step towards addressing #12 .

- Embrace `jaxls` batching whenever possible.
- Misc `forward_kinematics` speedups:
    - Allow `jax.lax.fori_loop` unrolling, seems helpful for collision-aware IK on GPU
    - Remove one of the branching calls from `fori_loop`