### PR TITLE
Update mimic joint implementation + bugfix

### DIFF
--- a/src/jaxmp/kinematics.py
+++ b/src/jaxmp/kinematics.py
@@ -62,9 +62,9 @@ class JaxKinTree:
     """Joint limit velocities for each joint; includes mimic and fixed joints."""
 
     # Mimic joint parameters.
-    mimic_multiplier: Float[Array, "joints"]
+    mimic_multiplier: Float[Array, " joints"]
     """Multiplier for mimic joints. 1.0 for non-mimic joints."""
-    mimic_offset: Float[Array, "joints"]
+    mimic_offset: Float[Array, " joints"]
     """Offset for mimic joints. 0.0 for non-mimic joints."""
 
     # Configuration.

--- a/src/jaxmp/kinematics.py
+++ b/src/jaxmp/kinematics.py
@@ -1,8 +1,9 @@
 """
 Differentiable robot kinematics model, implemented in JAX.
 Includes:
- - URDF parsing
- - Forward kinematics
+ - URDF parsing.
+ - Forward kinematics.
+ - Support for mimic joints.
 """
 
 # pylint: disable=invalid-name
@@ -26,76 +27,69 @@ from jaxtyping import Float, Int
 class JaxKinTree:
     """A differentiable robot kinematics tree."""
 
+    # Core joint parameters.
     num_joints: jdc.Static[int]
     """Number of joints in the robot."""
-
     num_actuated_joints: jdc.Static[int]
     """Number of actuated joints in the robot."""
-
-    joint_twists: Float[Array, "joints 6"]
-    """Twist parameters for each joint. Zero for fixed joints."""
-
-    Ts_parent_joint: Float[Array, "joints 7"]
-    """Transform from parent joint to current joint, in the format `joints 7`."""
-
-    idx_parent_joint: Int[Array, " joints"]
-    """Parent joint index for each joint. -1 for root."""
-
-    idx_actuated_joint: Int[Array, " joints"]
-    """Index of actuated joint for each joint, for handling mimic joints. -1 otherwise."""
-
-    limits_lower: Float[Array, " act_joints"]
-    """Lower joint limits for each actuated joint."""
-
-    limits_upper: Float[Array, " act_joints"]
-    """Upper joint limits for each actuated joint."""
-
-    _limits_lower_all: Float[Array, " joints"]
-    """Lower joint limits for each joint; includes mimic and fixed joints."""
-
-    _limits_upper_all: Float[Array, " joints"]
-    """Upper joint limits for each joint; includes mimic and fixed joints."""
-
     joint_names: jdc.Static[tuple[str]]
     """Names of the joints, in shape `joints`."""
 
+    # Joint relationships and transforms.
+    joint_twists: Float[Array, "joints 6"]
+    """Twist parameters for each joint. Zero for fixed joints."""
+    Ts_parent_joint: Float[Array, "joints 7"]
+    """Transform from parent joint to current joint, in the format `joints 7`."""
+    idx_parent_joint: Int[Array, " joints"]
+    """Parent joint index for each joint. -1 for root."""
+    idx_actuated_joint: Int[Array, " joints"]
+    """Index of actuated joint for each joint, for handling mimic joints. -1 otherwise."""
+
+    # Joint limits.
+    limits_lower: Float[Array, " act_joints"]
+    """Lower joint limits for each actuated joint."""
+    limits_upper: Float[Array, " act_joints"]
+    """Upper joint limits for each actuated joint."""
+    _limits_lower_all: Float[Array, " joints"]
+    """Lower joint limits for each joint; includes mimic and fixed joints."""
+    _limits_upper_all: Float[Array, " joints"]
+    """Upper joint limits for each joint; includes mimic and fixed joints."""
+
+    # Velocity limits.
     joint_vel_limit: Float[Array, " act_joints"]
     """Joint limit velocities for each actuated joint."""
-
     _joint_vel_limit_all: Float[Array, " joints"]
     """Joint limit velocities for each joint; includes mimic and fixed joints."""
 
-    unroll_fk: jdc.Static[bool]
-    """Whether to unroll the forward kinematics `fori_loop`.
-    Unrolling seems useful for collision-aware IK on GPU.
-    """
-
+    # Mimic joint parameters.
     mimic_multiplier: Float[Array, "joints"]
     """Multiplier for mimic joints. 1.0 for non-mimic joints."""
-
     mimic_offset: Float[Array, "joints"]
     """Offset for mimic joints. 0.0 for non-mimic joints."""
+
+    # Configuration.
+    unroll_fk: jdc.Static[bool]
+    """Whether to unroll the forward kinematics `fori_loop`."""
 
     @staticmethod
     def from_urdf(urdf: yourdfpy.URDF, unroll_fk: bool = False) -> JaxKinTree:
         """Build a differentiable robot model from a URDF."""
-
-        # Get the parent indices + joint twist parameters.
-        joint_twists = list[Array]()
-        Ts_parent_joint = list[Array]()
-        idx_parent_joint = list[int]()
-        idx_actuated_joint = list[int]()
-        limits_lower = list[float]()
-        limits_upper = list[float]()
-        limits_lower_all = list[float]()
-        limits_upper_all = list[float]()
-        joint_names = list[str]()
-        joint_vel_limits_all = list[float]()
-        joint_vel_limits = list[float]()
-
+        # Initialize lists to store joint parameters.
+        joint_twists = []
+        Ts_parent_joint = []
+        idx_parent_joint = []
+        idx_actuated_joint = []
+        limits_lower = []
+        limits_upper = []
+        limits_lower_all = []
+        limits_upper_all = []
+        joint_names = []
+        joint_vel_limits_all = []
+        joint_vel_limits = []
         mimic_multiplier = []
         mimic_offset = []
 
+        # Process each joint in the URDF.
         for joint_idx, joint in enumerate(urdf.joint_map.values()):
             # Get joint names.
             joint_names.append(joint.name)
@@ -104,26 +98,26 @@ class JaxKinTree:
             act_idx = JaxKinTree._get_act_joint_idx(urdf, joint, joint_idx)
             idx_actuated_joint.append(act_idx)
 
-            # Get the twist parameters for all movable joints.
+            # Process movable joints (actuated or mimic).
             if joint in urdf.actuated_joints or joint.mimic is not None:
                 twist = JaxKinTree._get_act_joint_twist(joint)
                 joint_twists.append(twist)
 
-                # Get the joint limits.
+                # Get joint limits.
                 lower, upper = JaxKinTree._get_joint_limits(joint)
-
                 if joint.mimic is None:
                     limits_lower.append(lower)
                     limits_upper.append(upper)
                 limits_lower_all.append(lower)
                 limits_upper_all.append(upper)
 
-                # Get the joint velocities.
+                # Get joint velocities.
                 joint_vel_limit = JaxKinTree._get_joint_limit_vel(joint)
                 joint_vel_limits_all.append(joint_vel_limit)
                 if joint.mimic is None:
                     joint_vel_limits.append(joint_vel_limit)
 
+                # Handle mimic joint parameters.
                 if joint.mimic is not None:
                     multiplier = (
                         1.0
@@ -137,7 +131,7 @@ class JaxKinTree:
                 mimic_multiplier.append(multiplier)
                 mimic_offset.append(offset)
             else:
-                # Fixed joint, no twist.
+                # Fixed joint handling.
                 joint_twists.append(jnp.zeros(6))
                 limits_lower_all.append(0)
                 limits_upper_all.append(0)
@@ -145,100 +139,73 @@ class JaxKinTree:
                 mimic_multiplier.append(1.0)
                 mimic_offset.append(0.0)
 
-            # Get the parent joint index and transform for each joint.
-            if joint.origin is None and joint.type == "fixed":
-                # Fixed joint, no transform.
-                logger.info("Found fixed joint with no origin, placing at origin.")
-                parent_idx = -1
-                T_parent_joint = jaxlie.SE3.identity().wxyz_xyz
-            else:
-                parent_idx, T_parent_joint = JaxKinTree._get_T_parent_joint(
-                    urdf, joint, joint_idx
-                )
+            # Get parent joint information.
+            parent_idx, T_parent_joint = JaxKinTree._get_T_parent_joint(
+                urdf, joint, joint_idx
+            )
             idx_parent_joint.append(parent_idx)
             Ts_parent_joint.append(T_parent_joint)
 
-        joint_twists = jnp.array(joint_twists)
-        Ts_parent_joint = jnp.array(Ts_parent_joint)
-        idx_parent_joint = jnp.array(idx_parent_joint)
-        idx_actuated_joint = jnp.array(idx_actuated_joint)
-        num_joints = len(urdf.joint_map)
-        num_actuated_joints = len(urdf.actuated_joints)
-        limits_lower = jnp.array(limits_lower)
-        limits_upper = jnp.array(limits_upper)
-        limits_lower_all = jnp.array(limits_lower_all)
-        limits_upper_all = jnp.array(limits_upper_all)
-        joint_names = tuple[str](joint_names)
-        joint_vel_limits_all = jnp.array(joint_vel_limits_all)
-        joint_vel_limits = jnp.array(joint_vel_limits)
-
-        mimic_multiplier = jnp.array(mimic_multiplier)
-        mimic_offset = jnp.array(mimic_offset)
-
-        assert idx_actuated_joint.shape == (num_joints,)
-        assert joint_twists.shape == (num_joints, 6)
-        assert Ts_parent_joint.shape == (num_joints, 7)
-        assert idx_parent_joint.shape == (num_joints,)
-        assert idx_actuated_joint.max() == num_actuated_joints - 1
-        assert limits_lower_all.shape == (num_joints,)
-        assert limits_upper_all.shape == (num_joints,)
-        assert len(joint_names) == num_joints
-        assert joint_vel_limits_all.shape == (num_joints,)
-        assert joint_vel_limits.shape == (num_actuated_joints,)
-
-        return JaxKinTree(
-            num_joints=num_joints,
-            num_actuated_joints=num_actuated_joints,
-            idx_actuated_joint=idx_actuated_joint,
-            joint_twists=joint_twists,
-            Ts_parent_joint=Ts_parent_joint,
-            idx_parent_joint=idx_parent_joint,
-            limits_lower=limits_lower,
-            limits_upper=limits_upper,
-            _limits_lower_all=limits_lower_all,
-            _limits_upper_all=limits_upper_all,
-            joint_names=joint_names,
-            joint_vel_limit=joint_vel_limits,
-            _joint_vel_limit_all=joint_vel_limits_all,
+        # Convert lists to arrays.
+        kin = JaxKinTree(
+            num_joints=len(urdf.joint_map),
+            num_actuated_joints=len(urdf.actuated_joints),
+            idx_actuated_joint=jnp.array(idx_actuated_joint),
+            joint_twists=jnp.array(joint_twists),
+            Ts_parent_joint=jnp.array(Ts_parent_joint),
+            idx_parent_joint=jnp.array(idx_parent_joint),
+            limits_lower=jnp.array(limits_lower),
+            limits_upper=jnp.array(limits_upper),
+            _limits_lower_all=jnp.array(limits_lower_all),
+            _limits_upper_all=jnp.array(limits_upper_all),
+            joint_names=tuple(joint_names),
+            joint_vel_limit=jnp.array(joint_vel_limits),
+            _joint_vel_limit_all=jnp.array(joint_vel_limits_all),
             unroll_fk=unroll_fk,
-            mimic_multiplier=mimic_multiplier,
-            mimic_offset=mimic_offset,
+            mimic_multiplier=jnp.array(mimic_multiplier),
+            mimic_offset=jnp.array(mimic_offset),
         )
+
+        # Shape assertions.
+        assert kin.joint_twists.shape == (kin.num_joints, 6)
+        assert kin.Ts_parent_joint.shape == (kin.num_joints, 7)
+        assert kin.idx_parent_joint.shape == (kin.num_joints,)
+        assert kin.idx_actuated_joint.shape == (kin.num_joints,)
+        assert kin.limits_lower.shape == (kin.num_actuated_joints,)
+        assert kin.limits_upper.shape == (kin.num_actuated_joints,)
+        assert kin._limits_lower_all.shape == (kin.num_joints,)
+        assert kin._limits_upper_all.shape == (kin.num_joints,)
+        assert kin.joint_vel_limit.shape == (kin.num_actuated_joints,)
+        assert kin._joint_vel_limit_all.shape == (kin.num_joints,)
+        assert kin.mimic_multiplier.shape == (kin.num_joints,)
+        assert kin.mimic_offset.shape == (kin.num_joints,)
+
+        return kin
 
     @staticmethod
     def _get_act_joint_idx(
         urdf: yourdfpy.URDF, joint: yourdfpy.Joint, joint_idx: int
     ) -> int:
         """Get the actuated joint index for a joint, checking for mimic joints."""
-        # Check if this joint is a mimic joint -- assume multiplier=1.0, offset=0.0.
         if joint.mimic is not None:
             mimicked_joint = urdf.joint_map[joint.mimic.joint]
             mimicked_joint_idx = urdf.actuated_joints.index(mimicked_joint)
             assert mimicked_joint_idx < joint_idx, "Code + fk `fori_loop` assumes this!"
             logger.warning("Mimic joint detected.")
-            act_joint_idx = urdf.actuated_joints.index(mimicked_joint)
-
-        # Track joint twists for actuated joints.
+            return urdf.actuated_joints.index(mimicked_joint)
         elif joint in urdf.actuated_joints:
             assert joint.axis.shape == (3,)
-            act_joint_idx = urdf.actuated_joints.index(joint)
-
-        # Not actuated.
-        else:
-            act_joint_idx = -1
-
-        return act_joint_idx
+            return urdf.actuated_joints.index(joint)
+        return -1
 
     @staticmethod
     def _get_act_joint_twist(joint: yourdfpy.Joint) -> Array:
         """Get the twist parameters for an actuated joint."""
         if joint.type in ("revolute", "continuous"):
-            twist = jnp.concatenate([jnp.zeros(3), joint.axis])
+            return jnp.concatenate([jnp.zeros(3), joint.axis])
         elif joint.type == "prismatic":
-            twist = jnp.concatenate([joint.axis, jnp.zeros(3)])
-        else:
-            raise ValueError(f"Unsupported joint type {joint.type}!")
-        return twist
+            return jnp.concatenate([joint.axis, jnp.zeros(3)])
+        raise ValueError(f"Unsupported joint type {joint.type}!")
 
     @staticmethod
     def _get_T_parent_joint(
@@ -246,47 +213,39 @@ class JaxKinTree:
         joint: yourdfpy.Joint,
         joint_idx: int,
     ) -> tuple[int, Array]:
-        """Get the transform from the parent joint to the current joint,
-        as well as the parent joint index."""
+        """Get the transform from the parent joint to the current joint and parent joint index."""
         assert joint.origin.shape == (4, 4)
-
         joint_from_child = {joint.child: joint for joint in urdf.joint_map.values()}
 
         T_parent_joint = joint.origin
         if joint.parent not in joint_from_child:
-            # Must be root node.
-            parent_index = -1
-        else:
-            parent_joint = joint_from_child[joint.parent]
-            parent_index = urdf.joint_names.index(parent_joint.name)
-            if parent_index >= joint_idx:
-                logger.warning(
-                    f"Parent index {parent_index} >= joint index {joint_idx}! "
-                    + "Assuming that parent is root."
-                )
-                if parent_joint.parent != urdf.scene.graph.base_frame:
-                    raise ValueError(
-                        "Parent index >= joint_index, but parent is not root!"
-                    )
-                T_parent_joint = parent_joint.origin @ T_parent_joint  # T_root_joint.
-                parent_index = -1
+            return -1, jaxlie.SE3.from_matrix(T_parent_joint).wxyz_xyz
 
-        return (parent_index, jaxlie.SE3.from_matrix(T_parent_joint).wxyz_xyz)
+        parent_joint = joint_from_child[joint.parent]
+        parent_index = urdf.joint_names.index(parent_joint.name)
+
+        if parent_index >= joint_idx:
+            logger.warning(
+                f"Parent index {parent_index} >= joint index {joint_idx}! "
+                "Assuming that parent is root."
+            )
+            if parent_joint.parent != urdf.scene.graph.base_frame:
+                raise ValueError("Parent index >= joint_index, but parent is not root!")
+            T_parent_joint = parent_joint.origin @ T_parent_joint  # T_root_joint
+            parent_index = -1
+
+        return parent_index, jaxlie.SE3.from_matrix(T_parent_joint).wxyz_xyz
 
     @staticmethod
     def _get_joint_limits(joint: yourdfpy.Joint) -> tuple[float, float]:
         """Get the joint limits for an actuated joint, returns (lower, upper)."""
         assert joint.limit is not None
         if joint.limit.lower is not None and joint.limit.upper is not None:
-            lower = joint.limit.lower
-            upper = joint.limit.upper
+            return joint.limit.lower, joint.limit.upper
         elif joint.type == "continuous":
             logger.warning("Continuous joint detected, cap to [-pi, pi] limits.")
-            lower = -jnp.pi
-            upper = jnp.pi
-        else:
-            raise ValueError("We currently assume there are joint limits!")
-        return lower, upper
+            return -jnp.pi, jnp.pi
+        raise ValueError("We currently assume there are joint limits!")
 
     @staticmethod
     def _get_joint_limit_vel(joint: yourdfpy.Joint) -> float:
@@ -298,13 +257,16 @@ class JaxKinTree:
 
     @jdc.jit
     def map_actuated_to_all_joints(
-        self, cfg: Float[Array, "*batch num_act_joints"]
+        self, cfg: Float[Array, "*batch num_act_joints"], apply_mimic_scale: bool = False
     ) -> Float[Array, "*batch num_joints"]:
-        """Expand the actuated joint configuration to the full joint configuration, to account for mimic joints.
-        Does not apply mimic multiplier/offset settings."""
+        """Expand the actuated joint configuration to the full joint configuration.
+        If `apply_mimic_scale` is True, the mimic multiplier/offset settings are applied."""
         batch_axes = cfg.shape[:-1]
         cfg = cfg[..., self.idx_actuated_joint]
         cfg = jnp.where(self.idx_actuated_joint == -1, 0.0, cfg)
+        assert cfg.shape == (*batch_axes, self.num_joints)
+        if apply_mimic_scale:
+            cfg = cfg * self.mimic_multiplier + self.mimic_offset
         assert cfg.shape == (*batch_axes, self.num_joints)
         return cfg
 
@@ -313,8 +275,7 @@ class JaxKinTree:
         self,
         cfg: Float[Array, "*batch num_act_joints"],
     ) -> Float[Array, "*batch num_joints 7"]:
-        """
-        Run forward kinematics on the robot, in the provided configuration.
+        """Run forward kinematics on the robot, in the provided configuration.
 
         Args:
             cfg: The configuration of the actuated joints, in the format `(*batch num_act_joints)`.
@@ -325,14 +286,11 @@ class JaxKinTree:
         batch_axes = cfg.shape[:-1]
         assert cfg.shape == (*batch_axes, self.num_actuated_joints)
 
-        cfg = self.map_actuated_to_all_joints(cfg)
+        # Map to full joint space and apply mimic scaling.
+        cfg = self.map_actuated_to_all_joints(cfg, apply_mimic_scale=True)
         assert cfg.shape == (*batch_axes, self.num_joints)
 
-        # Apply mimic joint scaling, if applicable.
-        cfg = cfg * self.mimic_multiplier + self.mimic_offset
-        assert cfg.shape == (*batch_axes, self.num_joints)
-
-        # Compute transforms for all joints
+        # Compute transforms for all joints.
         Ts_joint_child = jaxlie.SE3.exp(self.joint_twists * cfg[..., None]).wxyz_xyz
         assert Ts_joint_child.shape == (*batch_axes, self.num_joints, 7)
 
@@ -384,8 +342,7 @@ class JaxKinTree:
             assert cfg.shape[-1] == self.num_actuated_joints
 
             # Apply units to delta, by normalizing w/ the joint velocity.
-            # Important for robots with both revolute + prismatic joints
-            # (e.g., fetch, robot grippers).
+            # Important for robots with both revolute + prismatic joints.
             _delta = delta * self.joint_vel_limit * 0.01
 
             return cfg + _delta

--- a/src/jaxmp/robot_factors.py
+++ b/src/jaxmp/robot_factors.py
@@ -148,8 +148,7 @@ class RobotFactors:
             residual_upper = jnp.maximum(0.0, joint_cfg - kin._limits_upper_all)
             residual_lower = jnp.maximum(0.0, kin._limits_lower_all - joint_cfg)
             residual = residual_upper + residual_lower
-            assert residual.shape == weights.shape
-            return residual * weights
+            return residual * kin.map_actuated_to_all_joints(weights, apply_mimic_scale=False)
 
         return jaxls.Factor(limit_cost, (JointVarType(var_idx),))
 


### PR DESCRIPTION
- Fixes bug for joint topological sort implementation
- Improved handling of mimic joints (or rather, how it should have been done before):
   - Apply mimic joint multiplier
   - Use the joint's original joint axes/frame, don't copy joint twists from parent ...